### PR TITLE
PUPPET-1: Drops hardcoded protocol call password

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ graphdb_link { 'master-worker':
 }
 
 exec { 'enable-security':
+  require => graphdb::ee::worker::repository['worker'],
   path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
   command => "curl -k -X POST --header 'Content-Type: application/json' --header 'Accept: */*' -d 'true' 'https://localhost:8080/rest/security'",
   cwd  => '/',

--- a/lib/puppet/util/http_client.rb
+++ b/lib/puppet/util/http_client.rb
@@ -34,7 +34,6 @@ module Puppet
         request.set_form_data(parameters[:body_params]) if parameters.key?(:body_params)
         request.content_type = parameters[:content_type] if parameters.key?(:content_type)
         request['Accept'] = parameters[:accept_type] if parameters.key?(:accept_type)
-        request['Authorization'] = "Basic YWRtaW46cm9vdA=="
 
         set_auth(request, parameters) if parameters.key?(:auth)
       end


### PR DESCRIPTION
The issue is that protocol is not secured, and if the user changes the username/password with puppet prior to the validation, the result will be a 401.

Also a small improvement to the example in the README